### PR TITLE
Add Flask frontend for CSV transaction filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Financial Tracker
 
-This Streamlit application lets you import multiple bank statement CSV files, categorise your transactions, and analyse spending over custom date ranges or payday cycles.
+This Flask application lets you import one or more bank statement CSV files, filter transactions by type (for example, `BGC` fo
+r salary payments or `FPI` for standing orders), and review income/spending totals directly in the browser.
 
 ## Features
 
-- Upload any number of CSV statements that share the following columns: `Transaction Date`, `Transaction Type`, `Sort Code`, `Account Number`, `Transaction Description`, `Debit Amount`, `Credit Amount`, and `Balance`.
-- Delete previously imported files to remove their transactions from the analysis.
-- Bulk or individually categorise transactions with custom categories.
-- Filter by date range and category to review spending and income.
-- Visualise category totals and daily debit/credit trends.
-- Review a payday cycle (payday to the day before the next payday) to assess monthly financial health.
+- Upload any number of CSV statements that share the following columns: `Transaction Date`, `Transaction Type`, `Sort Code`, `Ac
+count Number`, `Transaction Description`, `Debit Amount`, `Credit Amount`, and `Balance`.
+- See a running table of all imported transactions and the original file each row came from.
+- Filter by transaction type to focus on deposits such as BGC salary payments or FPI transfers.
+- View instant totals for money received, money spent, and the resulting net figure for the filtered data.
+- Clear imported data at any time without restarting the server.
 
 ## Getting started
 
@@ -18,13 +19,14 @@ This Streamlit application lets you import multiple bank statement CSV files, ca
    pip install -r requirements.txt
    ```
 
-2. Run the Streamlit app:
+2. Run the Flask app:
    ```bash
-   streamlit run app.py
+   flask --app app.py run --host=0.0.0.0 --port=8000
    ```
 
-3. Open the provided URL in your browser, upload CSV files, and begin categorising and analysing your transactions.
+3. Open `http://localhost:8000` in your browser, upload CSV files, and filter transactions by type.
 
 ## CSV format
 
-Ensure your CSV files use `DD/MM/YYYY` for the transaction date and contain the columns listed above. Monetary values can include the `£` symbol and commas; they are cleaned during import.
+Ensure your CSV files use `DD/MM/YYYY` for the transaction date and contain the columns listed above. Monetary values can includ
+e the `£` symbol and commas; they are cleaned during import.

--- a/app.py
+++ b/app.py
@@ -1,12 +1,19 @@
-import hashlib
 import io
-from datetime import timedelta
-from typing import Dict, List
+import os
+import uuid
+from typing import Dict, List, Optional
 
-import altair as alt
 import pandas as pd
-import streamlit as st
-from streamlit.runtime.uploaded_file_manager import UploadedFile
+from flask import (
+    Flask,
+    flash,
+    get_flashed_messages,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 
 REQUIRED_COLUMNS = {
     "Transaction Date": "Transaction Date",
@@ -19,14 +26,15 @@ REQUIRED_COLUMNS = {
     "Balance": "Balance",
 }
 
-CATEGORY_COLUMN = "Category"
-SOURCE_ID_COLUMN = "Source Id"
-SOURCE_NAME_COLUMN = "Source"
 DATE_COLUMN = "Transaction Date"
+SESSION_DATA: Dict[str, pd.DataFrame] = {}
 
 
-@st.cache_data(show_spinner=False)
-def _read_csv(content: bytes) -> pd.DataFrame:
+def _format_currency(value: float) -> str:
+    return f"{value:,.2f}"
+
+
+def _read_csv(content: bytes, source_name: str) -> pd.DataFrame:
     buffer = io.BytesIO(content)
     df = pd.read_csv(buffer)
     df.columns = [col.strip() for col in df.columns]
@@ -51,277 +59,119 @@ def _read_csv(content: bytes) -> pd.DataFrame:
         )
         df[column] = pd.to_numeric(df[column], errors="coerce").fillna(0.0)
 
-    df[CATEGORY_COLUMN] = "Uncategorized"
+    df["Source"] = source_name
     return df
 
 
-def _initialise_state() -> None:
-    if "transactions" not in st.session_state:
-        st.session_state.transactions = pd.DataFrame(columns=list(REQUIRED_COLUMNS) + [CATEGORY_COLUMN, SOURCE_ID_COLUMN, SOURCE_NAME_COLUMN])
-    if "sources" not in st.session_state:
-        st.session_state.sources: Dict[str, str] = {}
-    if "custom_categories" not in st.session_state:
-        st.session_state.custom_categories: List[str] = []
+def _get_session_id() -> str:
+    if "session_id" not in session:
+        session["session_id"] = uuid.uuid4().hex
+    return session["session_id"]
 
 
-def _store_uploaded_files(files: List[UploadedFile]) -> None:
-    for uploaded in files:
-        content = uploaded.getvalue()
-        file_hash = hashlib.md5(content).hexdigest()
-        if file_hash in st.session_state.sources:
-            continue
-
-        try:
-            df = _read_csv(content)
-        except Exception as exc:
-            st.error(f"Could not import {uploaded.name}: {exc}")
-            continue
-
-        df[SOURCE_ID_COLUMN] = file_hash
-        df[SOURCE_NAME_COLUMN] = uploaded.name
-
-        st.session_state.transactions = pd.concat(
-            [st.session_state.transactions, df], ignore_index=True
-        )
-        st.session_state.sources[file_hash] = uploaded.name
+def _get_transactions() -> Optional[pd.DataFrame]:
+    session_id = _get_session_id()
+    return SESSION_DATA.get(session_id)
 
 
-def _delete_source(selected_name: str) -> None:
-    for source_id, name in list(st.session_state.sources.items()):
-        if name == selected_name:
-            st.session_state.transactions = st.session_state.transactions[
-                st.session_state.transactions[SOURCE_ID_COLUMN] != source_id
-            ].reset_index(drop=True)
-            del st.session_state.sources[source_id]
-            break
+def _store_transactions(data: pd.DataFrame) -> None:
+    session_id = _get_session_id()
+    SESSION_DATA[session_id] = data
 
 
-def _category_options() -> List[str]:
-    categories = set(st.session_state.transactions.get(CATEGORY_COLUMN, pd.Series()).unique())
-    categories.update(st.session_state.custom_categories)
-    categories.discard("Uncategorized")
-    return ["Uncategorized", *sorted(cat for cat in categories if isinstance(cat, str))]
+def _clear_transactions() -> None:
+    session_id = _get_session_id()
+    SESSION_DATA.pop(session_id, None)
 
 
-def _bulk_categorise(category: str, mask: pd.Series) -> None:
-    st.session_state.transactions.loc[mask, CATEGORY_COLUMN] = category
+app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", "dev-secret-key")
 
 
-def _render_summary(filtered: pd.DataFrame) -> None:
-    debit_total = filtered["Debit Amount"].sum()
-    credit_total = filtered["Credit Amount"].sum()
-    net = credit_total - debit_total
+@app.route("/", methods=["GET", "POST"])
+def index():
+    if request.method == "POST":
+        files = request.files.getlist("files")
+        valid_files = [file for file in files if file and file.filename]
 
-    left, middle, right = st.columns(3)
-    left.metric("Total Spent", f"£{debit_total:,.2f}")
-    middle.metric("Total Received", f"£{credit_total:,.2f}")
-    right.metric("Net", f"£{net:,.2f}")
+        if not valid_files:
+            flash("Please select at least one CSV file to upload.", "error")
+            return redirect(url_for("index"))
 
-    if not filtered.empty:
-        by_category = (
-            filtered.groupby(CATEGORY_COLUMN)["Debit Amount"].sum().reset_index().sort_values("Debit Amount", ascending=False)
-        )
-        by_category_chart = (
-            alt.Chart(by_category)
-            .mark_bar()
-            .encode(x=alt.X("Debit Amount", title="Total Spent (£)"), y=alt.Y(CATEGORY_COLUMN, sort="-x"))
-        )
-        st.altair_chart(by_category_chart, use_container_width=True)
+        frames: List[pd.DataFrame] = []
+        for file in valid_files:
+            try:
+                frames.append(_read_csv(file.read(), file.filename))
+            except Exception as exc:  # pylint: disable=broad-except
+                flash(f"Could not import {file.filename}: {exc}", "error")
 
-        trend_chart = (
-            alt.Chart(
-                filtered.assign(Date=filtered[DATE_COLUMN].dt.date)
-                .groupby("Date")
-                .agg({"Debit Amount": "sum", "Credit Amount": "sum"})
-                .reset_index()
-            )
-            .transform_fold(["Debit Amount", "Credit Amount"], as_=["Type", "Amount"])
-            .mark_line(point=True)
-            .encode(x="Date:T", y="Amount:Q", color="Type:N")
-        )
-        st.altair_chart(trend_chart, use_container_width=True)
+        if not frames:
+            return redirect(url_for("index"))
 
-        category_breakdown = (
-            filtered.groupby(CATEGORY_COLUMN)[["Debit Amount", "Credit Amount"]]
-            .sum()
-            .reset_index()
-            .sort_values("Debit Amount", ascending=False)
-        )
-    else:
-        st.info("No data available for the selected filters.")
-        category_breakdown = pd.DataFrame(columns=[CATEGORY_COLUMN, "Debit Amount", "Credit Amount"])
+        combined = pd.concat(frames, ignore_index=True)
+        combined.sort_values(DATE_COLUMN, inplace=True)
+        _store_transactions(combined)
+        flash(f"Imported {len(frames)} file(s) successfully.", "success")
+        return redirect(url_for("index"))
 
-    st.subheader("Category Breakdown")
-    st.dataframe(category_breakdown, use_container_width=True)
+    transactions = _get_transactions()
+    selected_type = request.args.get("transaction_type", "all")
+    filtered = None
+    transaction_types: List[str] = []
+    summary = None
+    table_rows: List[Dict[str, str]] = []
 
+    if transactions is not None and not transactions.empty:
+        transaction_types = sorted(transactions["Transaction Type"].dropna().unique())
+        filtered = transactions.copy()
+        if selected_type != "all":
+            filtered = filtered[filtered["Transaction Type"] == selected_type]
 
-_initialise_state()
-st.set_page_config(page_title="Financial Tracker", layout="wide")
-st.title("Financial Tracker")
+        if filtered.empty:
+            flash("No transactions match the selected filters.", "info")
+        else:
+            debit_total = filtered["Debit Amount"].sum()
+            credit_total = filtered["Credit Amount"].sum()
+            summary = {
+                "debit": _format_currency(debit_total),
+                "credit": _format_currency(credit_total),
+                "net": _format_currency(credit_total - debit_total),
+            }
 
-st.sidebar.header("Data Management")
-uploaded_files = st.sidebar.file_uploader(
-    "Upload transaction CSV files",
-    type=["csv"],
-    accept_multiple_files=True,
-)
-if uploaded_files:
-    _store_uploaded_files(uploaded_files)
+            display = filtered.copy()
+            display[DATE_COLUMN] = display[DATE_COLUMN].dt.strftime("%d/%m/%Y")
+            display["Debit Amount"] = display["Debit Amount"].map(_format_currency)
+            display["Credit Amount"] = display["Credit Amount"].map(_format_currency)
+            display["Balance"] = display["Balance"].map(_format_currency)
 
-if st.session_state.sources:
-    source_to_delete = st.sidebar.selectbox(
-        "Remove an imported file",
-        ["-"] + list(st.session_state.sources.values()),
-        key="delete_select",
-    )
-    if source_to_delete != "-" and st.sidebar.button("Delete selected file"):
-        _delete_source(source_to_delete)
-        st.sidebar.success(f"Removed {source_to_delete}")
+            columns = [
+                DATE_COLUMN,
+                "Transaction Type",
+                "Transaction Description",
+                "Debit Amount",
+                "Credit Amount",
+                "Balance",
+                "Source",
+            ]
+            table_rows = display[columns].to_dict(orient="records")
 
-if st.session_state.transactions.empty:
-    st.info("Upload one or more CSV files to begin.")
-    st.stop()
-
-transactions = st.session_state.transactions.copy()
-transactions[DATE_COLUMN] = pd.to_datetime(transactions[DATE_COLUMN])
-transactions.sort_values(DATE_COLUMN, inplace=True)
-
-st.sidebar.header("Filters")
-min_date = transactions[DATE_COLUMN].min().date()
-max_date = transactions[DATE_COLUMN].max().date()
-default_start = max(min_date, max_date - timedelta(days=30))
-default_range = (default_start, max_date)
-date_range = st.sidebar.date_input(
-    "Date range",
-    value=default_range,
-    min_value=min_date,
-    max_value=max_date,
-)
-if not isinstance(date_range, tuple) or len(date_range) != 2:
-    start_date, end_date = default_range
-else:
-    start_date, end_date = date_range
-
-if start_date > end_date:
-    start_date, end_date = end_date, start_date
-
-category_options = _category_options()
-selected_categories = st.sidebar.multiselect(
-    "Categories",
-    options=category_options,
-    default=category_options,
-)
-
-with st.expander("Bulk categorise transactions"):
-    new_category = st.text_input("Add a new category")
-    if new_category:
-        if new_category not in st.session_state.custom_categories:
-            st.session_state.custom_categories.append(new_category)
-        st.success(f"Added category '{new_category}'")
-
-    available_categories = [cat for cat in _category_options() if cat != "Uncategorized"]
-    if not available_categories:
-        available_categories = ["Uncategorized"]
-
-    selected_category = st.selectbox("Category to apply", options=available_categories)
-    description_keyword = st.text_input(
-        "Description contains (optional)",
-        help="Apply the category to any transactions containing this text.",
-    )
-    transaction_type = st.selectbox(
-        "Transaction type (optional)",
-        options=["Any"] + sorted(transactions["Transaction Type"].unique().tolist()),
+    return render_template(
+        "index.html",
+        transactions_available=transactions is not None and not transactions.empty,
+        transaction_types=transaction_types,
+        selected_type=selected_type,
+        summary=summary,
+        table_rows=table_rows,
+        messages=get_flashed_messages(with_categories=True),
     )
 
-    mask = pd.Series(True, index=transactions.index, dtype=bool)
-    if description_keyword:
-        mask &= transactions["Transaction Description"].str.contains(description_keyword, case=False, na=False)
-    if transaction_type != "Any":
-        mask &= transactions["Transaction Type"] == transaction_type
 
-    st.write(f"Matching transactions: {int(mask.sum())}")
-    if st.button("Apply category", disabled=mask.sum() == 0):
-        _bulk_categorise(selected_category, mask)
-        transactions = st.session_state.transactions.copy()
-        transactions[DATE_COLUMN] = pd.to_datetime(transactions[DATE_COLUMN])
-        transactions.sort_values(DATE_COLUMN, inplace=True)
-        st.success("Category applied")
+@app.post("/clear")
+def clear_transactions():
+    _clear_transactions()
+    flash("Cleared imported transactions.", "success")
+    return redirect(url_for("index"))
 
-st.subheader("Categorise individually")
-category_editor = st.data_editor(
-    transactions[
-        [
-            DATE_COLUMN,
-            "Transaction Description",
-            "Transaction Type",
-            "Debit Amount",
-            "Credit Amount",
-            CATEGORY_COLUMN,
-            SOURCE_NAME_COLUMN,
-        ]
-    ],
-    num_rows="fixed",
-    hide_index=True,
-    column_config={
-        CATEGORY_COLUMN: st.column_config.SelectboxColumn(
-            CATEGORY_COLUMN,
-            options=_category_options(),
-        )
-    },
-    key="category_editor",
-)
 
-st.session_state.transactions.loc[category_editor.index, CATEGORY_COLUMN] = category_editor[CATEGORY_COLUMN].values
-
-transactions = st.session_state.transactions.copy()
-transactions[DATE_COLUMN] = pd.to_datetime(transactions[DATE_COLUMN])
-transactions.sort_values(DATE_COLUMN, inplace=True)
-
-filtered_transactions = transactions[
-    (transactions[DATE_COLUMN].dt.date >= start_date)
-    & (transactions[DATE_COLUMN].dt.date <= end_date)
-    & (transactions[CATEGORY_COLUMN].isin(selected_categories))
-]
-
-st.subheader("Filtered results")
-st.dataframe(
-    filtered_transactions[[
-        DATE_COLUMN,
-        "Transaction Type",
-        "Transaction Description",
-        "Debit Amount",
-        "Credit Amount",
-        CATEGORY_COLUMN,
-        SOURCE_NAME_COLUMN,
-    ]],
-    use_container_width=True,
-)
-
-_render_summary(filtered_transactions)
-
-st.subheader("Pay period view")
-payday = st.date_input("Most recent payday", value=max_date)
-cycle_length = st.number_input("Cycle length (days)", min_value=7, max_value=35, value=30)
-period_start, period_end = payday, payday + timedelta(days=cycle_length - 1)
-
-pay_period_mask = (
-    (transactions[DATE_COLUMN].dt.date >= period_start)
-    & (transactions[DATE_COLUMN].dt.date <= period_end)
-)
-pay_period_transactions = transactions[pay_period_mask]
-st.write(f"Showing transactions from {period_start} to {period_end}")
-st.dataframe(
-    pay_period_transactions[[
-        DATE_COLUMN,
-        "Transaction Description",
-        "Debit Amount",
-        "Credit Amount",
-        CATEGORY_COLUMN,
-    ]],
-    use_container_width=True,
-)
-
-if not pay_period_transactions.empty:
-    _render_summary(pay_period_transactions)
-else:
-    st.info("No transactions in the selected pay period.")
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8000)), debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-streamlit==1.33.0
+Flask==2.3.3
 pandas==2.1.4
-altair==5.2.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,306 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Financial Tracker</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background-color: #f5f7fb;
+        color: #1f2933;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      main {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 2.5rem 1.5rem 4rem;
+      }
+
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 0.5rem;
+      }
+
+      h2 {
+        font-size: 1.25rem;
+        margin: 2rem 0 0.75rem;
+      }
+
+      p.lead {
+        margin-top: 0;
+        color: #52606d;
+      }
+
+      .card {
+        background: #ffffff;
+        border-radius: 16px;
+        padding: 1.75rem;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+        margin-bottom: 1.5rem;
+      }
+
+      .upload {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      label {
+        font-weight: 600;
+      }
+
+      input[type="file"],
+      select,
+      button {
+        font: inherit;
+      }
+
+      input[type="file"] {
+        padding: 0.5rem;
+        border: 1px solid #d2d6dc;
+        border-radius: 12px;
+        background: #f9fafc;
+      }
+
+      button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.6rem 1.5rem;
+        background: #2563eb;
+        color: #ffffff;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+
+      button:hover {
+        background: #1d4ed8;
+      }
+
+      .secondary-button {
+        background: #e4e7eb;
+        color: #1f2933;
+      }
+
+      .secondary-button:hover {
+        background: #cbd2d9;
+      }
+
+      .messages {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        margin: 1rem 0;
+      }
+
+      .message {
+        border-radius: 12px;
+        padding: 0.9rem 1.1rem;
+        font-weight: 500;
+      }
+
+      .message.error {
+        background: #fee2e2;
+        color: #7f1d1d;
+      }
+
+      .message.success {
+        background: #dcfce7;
+        color: #14532d;
+      }
+
+      .message.info {
+        background: #dbeafe;
+        color: #1e3a8a;
+      }
+
+      .filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: flex-end;
+      }
+
+      select {
+        padding: 0.5rem 0.75rem;
+        border-radius: 12px;
+        border: 1px solid #d2d6dc;
+        background: #ffffff;
+      }
+
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+      }
+
+      .summary-card {
+        background: linear-gradient(135deg, #2563eb, #1d4ed8);
+        color: #ffffff;
+        border-radius: 16px;
+        padding: 1.25rem;
+      }
+
+      .summary-card h3 {
+        margin: 0 0 0.35rem;
+        font-size: 1rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+
+      .summary-card p {
+        margin: 0;
+        font-size: 1.6rem;
+        font-weight: 600;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: #ffffff;
+        border-radius: 16px;
+        overflow: hidden;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.06);
+      }
+
+      thead {
+        background: #f0f4ff;
+      }
+
+      th, td {
+        padding: 0.9rem 1rem;
+        text-align: left;
+        font-size: 0.95rem;
+      }
+
+      tbody tr:nth-child(even) {
+        background: #f9fafc;
+      }
+
+      @media (max-width: 720px) {
+        .filters {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        button {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Financial Tracker</h1>
+        <p class="lead">Import your bank statements, then focus on the transactions that matter to you.</p>
+      </header>
+
+      {% if messages %}
+        <div class="messages">
+          {% for category, message in messages %}
+            <div class="message {{ category }}">{{ message }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      <section class="card">
+        <h2>Upload CSV statements</h2>
+        <form class="upload" method="post" enctype="multipart/form-data">
+          <label for="files">Select one or more CSV files</label>
+          <input id="files" name="files" type="file" accept=".csv" multiple required>
+          <p class="help">Files must include the columns Transaction Date, Transaction Type, Description, Debit, Credit, and Balance.</p>
+          <div>
+            <button type="submit">Import transactions</button>
+          </div>
+        </form>
+        {% if transactions_available %}
+          <form method="post" action="{{ url_for('clear_transactions') }}" style="margin-top: 1rem;">
+            <button class="secondary-button" type="submit">Clear imported data</button>
+          </form>
+        {% endif %}
+      </section>
+
+      {% if transactions_available %}
+        <section class="card">
+          <h2>Filter your data</h2>
+          <form class="filters" method="get">
+            <div>
+              <label for="transaction_type">Transaction type</label><br>
+              <select id="transaction_type" name="transaction_type">
+                <option value="all" {% if selected_type == 'all' %}selected{% endif %}>All types</option>
+                {% for t in transaction_types %}
+                  <option value="{{ t }}" {% if selected_type == t %}selected{% endif %}>{{ t }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div>
+              <button type="submit">Apply filters</button>
+            </div>
+          </form>
+        </section>
+
+        {% if summary %}
+          <section class="card">
+            <h2>Summary</h2>
+            <div class="summary-grid">
+              <div class="summary-card">
+                <h3>Total Spent</h3>
+                <p>£{{ summary['debit'] }}</p>
+              </div>
+              <div class="summary-card">
+                <h3>Total Received</h3>
+                <p>£{{ summary['credit'] }}</p>
+              </div>
+              <div class="summary-card">
+                <h3>Net</h3>
+                <p>£{{ summary['net'] }}</p>
+              </div>
+            </div>
+          </section>
+
+          <section class="card">
+            <h2>Transactions</h2>
+            <div class="table-wrapper">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Type</th>
+                    <th>Description</th>
+                    <th>Debit (£)</th>
+                    <th>Credit (£)</th>
+                    <th>Balance (£)</th>
+                    <th>Source</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for row in table_rows %}
+                    <tr>
+                      <td>{{ row['Transaction Date'] }}</td>
+                      <td>{{ row['Transaction Type'] }}</td>
+                      <td>{{ row['Transaction Description'] }}</td>
+                      <td>{{ row['Debit Amount'] }}</td>
+                      <td>{{ row['Credit Amount'] }}</td>
+                      <td>{{ row['Balance'] }}</td>
+                      <td>{{ row['Source'] }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        {% endif %}
+      {% endif %}
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the previous Streamlit experience with a Flask server that ingests CSV uploads and keeps transactions per session
- add a responsive HTML template so users can upload statements, filter by transaction type (BGC, FPI, etc.), and review totals
- refresh the README and dependencies to document the Flask workflow

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68dd259b5010832f9d3004c2c915fadb