### PR TITLE
Add browser-based CSV financial tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Financial Tracker</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
+    <script src="script.js" type="module" defer></script>
+</head>
+<body>
+    <header class="app-header">
+        <h1>Financial Tracker</h1>
+        <p>Upload, categorise, and analyse your bank transactions with ease.</p>
+    </header>
+
+    <main class="layout">
+        <section class="card" aria-labelledby="upload-title">
+            <div class="card-header">
+                <h2 id="upload-title">Import statements</h2>
+                <p>Upload one or multiple CSV statements to get started.</p>
+            </div>
+            <div class="upload-area">
+                <label class="upload-button">
+                    <input type="file" id="file-input" accept=".csv" multiple />
+                    <span>Choose CSV files</span>
+                </label>
+                <ul id="file-list" class="file-list" aria-live="polite"></ul>
+            </div>
+        </section>
+
+        <section class="card" aria-labelledby="category-title">
+            <div class="card-header">
+                <h2 id="category-title">Manage categories</h2>
+                <p>Create custom categories for your spending and income.</p>
+            </div>
+            <form id="category-form" class="category-form">
+                <label for="new-category" class="visually-hidden">New category</label>
+                <input id="new-category" type="text" placeholder="Add a new category" />
+                <button type="submit">Add</button>
+            </form>
+            <div id="category-pills" class="category-pills" aria-live="polite"></div>
+        </section>
+
+        <section class="card" aria-labelledby="filters-title">
+            <div class="card-header">
+                <h2 id="filters-title">Filters</h2>
+                <p>Combine filters to focus on the transactions that matter.</p>
+            </div>
+            <form id="filters" class="filters" autocomplete="off">
+                <div class="filter-group">
+                    <label for="start-date">From</label>
+                    <input type="date" id="start-date" />
+                </div>
+                <div class="filter-group">
+                    <label for="end-date">To</label>
+                    <input type="date" id="end-date" />
+                </div>
+                <fieldset class="filter-group">
+                    <legend>Transaction type</legend>
+                    <div id="type-options" class="chip-group"></div>
+                </fieldset>
+                <fieldset class="filter-group">
+                    <legend>Category</legend>
+                    <div id="category-options" class="chip-group"></div>
+                </fieldset>
+                <button type="button" id="reset-filters" class="secondary">Reset filters</button>
+            </form>
+        </section>
+
+        <section class="card" aria-labelledby="payday-title">
+            <div class="card-header">
+                <h2 id="payday-title">Payday view</h2>
+                <p>Select your payday to analyse the full pay cycle.</p>
+            </div>
+            <form id="payday-form" class="payday-form" autocomplete="off">
+                <div class="filter-group">
+                    <label for="payday-day">Payday (day of month)</label>
+                    <input type="number" id="payday-day" min="1" max="31" placeholder="e.g. 25" />
+                </div>
+                <div class="filter-group">
+                    <label for="payday-month">Month</label>
+                    <input type="month" id="payday-month" />
+                </div>
+                <button type="submit">Apply payday range</button>
+            </form>
+            <p class="payday-note" id="payday-note" aria-live="polite"></p>
+        </section>
+
+        <section class="card card-wide" aria-labelledby="summary-title">
+            <div class="card-header">
+                <h2 id="summary-title">Summary</h2>
+            </div>
+            <div class="summary-grid">
+                <div class="summary-item">
+                    <span class="summary-label">Transactions</span>
+                    <span id="summary-count" class="summary-value">0</span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Total out</span>
+                    <span id="summary-debit" class="summary-value negative">£0.00</span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Total in</span>
+                    <span id="summary-credit" class="summary-value positive">£0.00</span>
+                </div>
+                <div class="summary-item">
+                    <span class="summary-label">Net</span>
+                    <span id="summary-net" class="summary-value">£0.00</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="card card-wide" aria-labelledby="bulk-actions-title">
+            <div class="card-header">
+                <h2 id="bulk-actions-title">Categorise transactions</h2>
+            </div>
+            <div class="bulk-actions">
+                <div class="bulk-controls">
+                    <label for="bulk-category">Apply category to selected</label>
+                    <select id="bulk-category"></select>
+                </div>
+                <button type="button" id="apply-bulk" class="primary">Apply</button>
+                <span id="selection-count" class="selection-count">0 selected</span>
+            </div>
+        </section>
+
+        <section class="card card-wide" aria-labelledby="table-title">
+            <div class="card-header">
+                <h2 id="table-title">Transactions</h2>
+                <p id="table-caption">Select rows to bulk categorise or adjust categories one by one.</p>
+            </div>
+            <div class="table-container">
+                <table aria-describedby="table-caption">
+                    <thead>
+                        <tr>
+                            <th scope="col">
+                                <input type="checkbox" id="select-all" aria-label="Select all" />
+                            </th>
+                            <th scope="col">Date</th>
+                            <th scope="col">Type</th>
+                            <th scope="col">Description</th>
+                            <th scope="col">Debit (£)</th>
+                            <th scope="col">Credit (£)</th>
+                            <th scope="col">Balance (£)</th>
+                            <th scope="col">Category</th>
+                            <th scope="col">Source</th>
+                        </tr>
+                    </thead>
+                    <tbody id="transactions-body"></tbody>
+                </table>
+            </div>
+            <p id="empty-state" class="empty-state" hidden>No transactions match your filters.</p>
+        </section>
+
+        <section class="card card-wide" aria-labelledby="chart-title">
+            <div class="card-header">
+                <h2 id="chart-title">Spending by category</h2>
+            </div>
+            <div class="chart-wrapper">
+                <canvas id="category-chart" aria-label="Spending by category"></canvas>
+            </div>
+        </section>
+    </main>
+
+    <footer class="app-footer">
+        <p>All calculations happen in your browser. Data is never uploaded.</p>
+    </footer>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,579 @@
+const state = {
+    files: new Map(),
+    transactions: [],
+    categories: new Set([
+        'Uncategorised',
+        'Housing',
+        'Utilities',
+        'Groceries',
+        'Transport',
+        'Entertainment',
+        'Subscriptions',
+        'Health',
+        'Savings',
+        'Income'
+    ]),
+    selection: new Set(),
+    filters: {
+        startDate: '',
+        endDate: '',
+        types: new Set(),
+        categories: new Set()
+    }
+};
+
+let fileCounter = 0;
+let transactionCounter = 0;
+let chartInstance = null;
+
+const fileInput = document.getElementById('file-input');
+const fileList = document.getElementById('file-list');
+const categoryForm = document.getElementById('category-form');
+const categoryInput = document.getElementById('new-category');
+const categoryPills = document.getElementById('category-pills');
+const filtersForm = document.getElementById('filters');
+const startDateInput = document.getElementById('start-date');
+const endDateInput = document.getElementById('end-date');
+const typeOptions = document.getElementById('type-options');
+const categoryOptions = document.getElementById('category-options');
+const resetFiltersButton = document.getElementById('reset-filters');
+const paydayForm = document.getElementById('payday-form');
+const paydayDayInput = document.getElementById('payday-day');
+const paydayMonthInput = document.getElementById('payday-month');
+const paydayNote = document.getElementById('payday-note');
+const summaryCount = document.getElementById('summary-count');
+const summaryDebit = document.getElementById('summary-debit');
+const summaryCredit = document.getElementById('summary-credit');
+const summaryNet = document.getElementById('summary-net');
+const transactionsBody = document.getElementById('transactions-body');
+const selectAllCheckbox = document.getElementById('select-all');
+const bulkCategorySelect = document.getElementById('bulk-category');
+const applyBulkButton = document.getElementById('apply-bulk');
+const selectionCount = document.getElementById('selection-count');
+const emptyState = document.getElementById('empty-state');
+
+fileInput.addEventListener('change', handleFileSelection);
+categoryForm.addEventListener('submit', handleAddCategory);
+startDateInput.addEventListener('change', () => updateFilter('startDate', startDateInput.value));
+endDateInput.addEventListener('change', () => updateFilter('endDate', endDateInput.value));
+resetFiltersButton.addEventListener('click', resetFilters);
+paydayForm.addEventListener('submit', handlePaydaySubmit);
+selectAllCheckbox.addEventListener('change', handleSelectAll);
+applyBulkButton.addEventListener('click', applyBulkCategory);
+
+document.addEventListener('DOMContentLoaded', () => {
+    renderCategoryPills();
+    refreshCategorySelects();
+    renderFilterOptions();
+    render();
+});
+
+function handleFileSelection(event) {
+    const files = Array.from(event.target.files || []);
+    if (!files.length) {
+        return;
+    }
+
+    files.forEach(file => parseCsv(file));
+    event.target.value = '';
+}
+
+function parseCsv(file) {
+    const fileId = `file-${++fileCounter}`;
+
+    Papa.parse(file, {
+        header: true,
+        skipEmptyLines: true,
+        complete: (results) => {
+            if (results.errors.length) {
+                console.error('Failed to parse file', file.name, results.errors);
+                return;
+            }
+
+            const parsedTransactions = results.data
+                .map(row => normaliseRow(row, fileId, file.name))
+                .filter(Boolean);
+
+            if (!parsedTransactions.length) {
+                return;
+            }
+
+            state.files.set(fileId, {
+                id: fileId,
+                name: file.name,
+                count: parsedTransactions.length
+            });
+
+            state.transactions.push(...parsedTransactions);
+            renderFileList();
+            refreshTypeFilterOptions();
+            render();
+        }
+    });
+}
+
+function normaliseRow(row, fileId, fileName) {
+    const dateValue = (row['Transaction Date'] || row['Date'] || '').trim();
+    const type = (row['Transaction Type'] || row['Type'] || '').trim();
+    const description = (row['Transaction Description'] || row['Description'] || '').trim();
+    const debitRaw = row['Debit Amount'] ?? row['Debit'] ?? '';
+    const creditRaw = row['Credit Amount'] ?? row['Credit'] ?? '';
+    const balanceRaw = row['Balance'] ?? '';
+
+    if (!dateValue || (!debitRaw && !creditRaw && !description)) {
+        return null;
+    }
+
+    const date = parseDate(dateValue);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    const hasDebit = hasNumericValue(debitRaw);
+    const hasCredit = hasNumericValue(creditRaw);
+    const hasBalance = hasNumericValue(balanceRaw);
+    const debit = hasDebit ? parseAmount(debitRaw) : 0;
+    const credit = hasCredit ? parseAmount(creditRaw) : 0;
+    const balance = hasBalance ? parseAmount(balanceRaw) : null;
+
+    return {
+        id: `tx-${++transactionCounter}`,
+        fileId,
+        fileName,
+        date,
+        type,
+        description,
+        debit,
+        credit,
+        balance,
+        hasDebit,
+        hasCredit,
+        hasBalance,
+        category: 'Uncategorised'
+    };
+}
+
+function parseDate(value) {
+    const trimmed = value.trim();
+    const parts = trimmed.split(/[\/\-]/);
+    if (parts.length === 3) {
+        let [day, month, year] = parts.map(part => part.replace(/[^0-9]/g, ''));
+        if (year && year.length === 2) {
+            year = `20${year}`;
+        }
+        const dayNum = Number(day);
+        const monthNum = Number(month) - 1;
+        const yearNum = Number(year);
+        return new Date(yearNum, monthNum, dayNum);
+    }
+    return new Date(trimmed);
+}
+
+function parseAmount(value) {
+    if (value === null || value === undefined) {
+        return 0;
+    }
+    const normalised = String(value).replace(/[^0-9.-]/g, '');
+    const amount = Number.parseFloat(normalised);
+    return Number.isFinite(amount) ? amount : 0;
+}
+
+function hasNumericValue(value) {
+    if (value === null || value === undefined) {
+        return false;
+    }
+    return String(value).trim() !== '';
+}
+
+function renderFileList() {
+    fileList.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+
+    Array.from(state.files.values()).forEach(file => {
+        const li = document.createElement('li');
+        li.className = 'file-item';
+        li.innerHTML = `
+            <span>${file.name} <small>(${file.count} transactions)</small></span>
+            <button type="button" data-file-id="${file.id}">Remove</button>
+        `;
+        li.querySelector('button').addEventListener('click', () => removeFile(file.id));
+        fragment.appendChild(li);
+    });
+
+    fileList.appendChild(fragment);
+}
+
+function removeFile(fileId) {
+    state.files.delete(fileId);
+    state.transactions = state.transactions.filter(tx => tx.fileId !== fileId);
+    state.selection.clear();
+    renderFileList();
+    refreshTypeFilterOptions();
+    render();
+}
+
+function handleAddCategory(event) {
+    event.preventDefault();
+    const value = categoryInput.value.trim();
+    if (!value) {
+        return;
+    }
+    state.categories.add(value);
+    categoryInput.value = '';
+    renderCategoryPills();
+    refreshCategorySelects();
+    renderFilterOptions();
+    render();
+}
+
+function renderCategoryPills() {
+    categoryPills.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    getSortedCategories().forEach(category => {
+        const pill = document.createElement('span');
+        pill.className = 'category-pill';
+        pill.textContent = category;
+        fragment.appendChild(pill);
+    });
+    categoryPills.appendChild(fragment);
+}
+
+function getSortedCategories() {
+    const categories = Array.from(state.categories);
+    categories.sort((a, b) => a.localeCompare(b));
+    const index = categories.indexOf('Uncategorised');
+    if (index > 0) {
+        categories.splice(index, 1);
+        categories.unshift('Uncategorised');
+    }
+    return categories;
+}
+
+function refreshCategorySelects() {
+    const categories = getSortedCategories();
+    bulkCategorySelect.innerHTML = categories
+        .map(category => `<option value="${category}">${category}</option>`)
+        .join('');
+}
+
+function renderFilterOptions() {
+    refreshTypeFilterOptions();
+    refreshCategoryFilterOptions();
+}
+
+function refreshTypeFilterOptions() {
+    const uniqueTypes = new Set(state.transactions.map(tx => tx.type).filter(Boolean));
+    typeOptions.innerHTML = '';
+    uniqueTypes.forEach(type => {
+        const label = document.createElement('label');
+        label.className = 'chip';
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.value = type;
+        input.checked = state.filters.types.has(type);
+        input.addEventListener('change', () => toggleFilterSet(state.filters.types, type));
+        label.append(input, document.createTextNode(type));
+        typeOptions.appendChild(label);
+    });
+}
+
+function refreshCategoryFilterOptions() {
+    const categories = getSortedCategories();
+    categoryOptions.innerHTML = '';
+    categories.forEach(category => {
+        const label = document.createElement('label');
+        label.className = 'chip';
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.value = category;
+        input.checked = state.filters.categories.has(category);
+        input.addEventListener('change', () => toggleFilterSet(state.filters.categories, category));
+        label.append(input, document.createTextNode(category));
+        categoryOptions.appendChild(label);
+    });
+}
+
+function toggleFilterSet(set, value) {
+    if (set.has(value)) {
+        set.delete(value);
+    } else {
+        set.add(value);
+    }
+    render();
+}
+
+function updateFilter(key, value) {
+    state.filters[key] = value;
+    render();
+}
+
+function resetFilters() {
+    state.filters.startDate = '';
+    state.filters.endDate = '';
+    state.filters.types.clear();
+    state.filters.categories.clear();
+    startDateInput.value = '';
+    endDateInput.value = '';
+    paydayNote.textContent = '';
+    renderFilterOptions();
+    render();
+}
+
+function handlePaydaySubmit(event) {
+    event.preventDefault();
+    const day = Number(paydayDayInput.value);
+    const monthValue = paydayMonthInput.value;
+    if (!day || !monthValue) {
+        return;
+    }
+    const [year, month] = monthValue.split('-').map(Number);
+    const start = new Date(year, month - 1, day);
+    const end = new Date(year, month, day);
+    end.setDate(end.getDate() - 1);
+
+    const startIso = start.toISOString().split('T')[0];
+    const endIso = end.toISOString().split('T')[0];
+
+    startDateInput.value = startIso;
+    endDateInput.value = endIso;
+    updateFilter('startDate', startIso);
+    updateFilter('endDate', endIso);
+
+    paydayNote.textContent = `Showing transactions from ${formatDisplayDate(start)} to ${formatDisplayDate(end)}.`;
+}
+
+function formatDisplayDate(date) {
+    return date.toLocaleDateString('en-GB', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric'
+    });
+}
+
+function applyFilters(transactions) {
+    return transactions.filter(tx => {
+        if (state.filters.startDate) {
+            const start = new Date(state.filters.startDate);
+            if (tx.date < start) {
+                return false;
+            }
+        }
+        if (state.filters.endDate) {
+            const end = new Date(state.filters.endDate);
+            end.setHours(23, 59, 59, 999);
+            if (tx.date > end) {
+                return false;
+            }
+        }
+        if (state.filters.types.size && !state.filters.types.has(tx.type)) {
+            return false;
+        }
+        if (state.filters.categories.size && !state.filters.categories.has(tx.category)) {
+            return false;
+        }
+        return true;
+    });
+}
+
+function render() {
+    const filteredTransactions = applyFilters(state.transactions);
+    filteredTransactions.sort((a, b) => b.date - a.date);
+    renderTransactions(filteredTransactions);
+    renderSummary(filteredTransactions);
+    renderChart(filteredTransactions);
+    updateSelectionState(filteredTransactions);
+}
+
+function renderTransactions(transactions) {
+    transactionsBody.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+
+    transactions.forEach(tx => {
+        const row = document.createElement('tr');
+        if (state.selection.has(tx.id)) {
+            row.classList.add('selected');
+        }
+
+        const checkboxCell = document.createElement('td');
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = state.selection.has(tx.id);
+        checkbox.addEventListener('change', () => toggleSelection(tx.id));
+        checkboxCell.appendChild(checkbox);
+        row.appendChild(checkboxCell);
+
+        row.appendChild(createCell(formatDisplayDate(tx.date)));
+        row.appendChild(createCell(tx.type || '—'));
+        row.appendChild(createCell(tx.description || '—'));
+        row.appendChild(createCell(tx.hasDebit ? formatCurrency(tx.debit) : '—'));
+        row.appendChild(createCell(tx.hasCredit ? formatCurrency(tx.credit) : '—'));
+        row.appendChild(createCell(tx.hasBalance ? formatCurrency(tx.balance) : '—'));
+
+        const categoryCell = document.createElement('td');
+        const select = document.createElement('select');
+        getSortedCategories().forEach(category => {
+            const option = document.createElement('option');
+            option.value = category;
+            option.textContent = category;
+            select.appendChild(option);
+        });
+        if (!state.categories.has(tx.category)) {
+            state.categories.add(tx.category);
+            refreshCategorySelects();
+            renderFilterOptions();
+        }
+        select.value = tx.category;
+        select.addEventListener('change', () => {
+            tx.category = select.value;
+            render();
+        });
+        categoryCell.appendChild(select);
+        row.appendChild(categoryCell);
+
+        row.appendChild(createCell(tx.fileName));
+
+        fragment.appendChild(row);
+    });
+
+    transactionsBody.appendChild(fragment);
+    emptyState.hidden = transactions.length > 0;
+}
+
+function createCell(content) {
+    const cell = document.createElement('td');
+    cell.textContent = content;
+    return cell;
+}
+
+function formatCurrency(value) {
+    if (!value) {
+        return '£0.00';
+    }
+    const sign = value < 0 ? '-' : '';
+    const absolute = Math.abs(value);
+    return `${sign}£${absolute.toLocaleString('en-GB', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    })}`;
+}
+
+function renderSummary(transactions) {
+    const totalDebit = transactions.reduce((sum, tx) => sum + tx.debit, 0);
+    const totalCredit = transactions.reduce((sum, tx) => sum + tx.credit, 0);
+    const net = totalCredit - totalDebit;
+
+    summaryCount.textContent = transactions.length.toLocaleString();
+    summaryDebit.textContent = formatCurrency(totalDebit);
+    summaryCredit.textContent = formatCurrency(totalCredit);
+    summaryNet.textContent = formatCurrency(net);
+
+    summaryNet.classList.toggle('positive', net >= 0);
+    summaryNet.classList.toggle('negative', net < 0);
+}
+
+function renderChart(transactions) {
+    const canvas = document.getElementById('category-chart');
+    const spendingByCategory = new Map();
+
+    transactions.forEach(tx => {
+        const amount = tx.debit;
+        if (!amount) {
+            return;
+        }
+        const current = spendingByCategory.get(tx.category) ?? 0;
+        spendingByCategory.set(tx.category, current + amount);
+    });
+
+    const labels = Array.from(spendingByCategory.keys());
+    const data = Array.from(spendingByCategory.values());
+
+    if (chartInstance) {
+        chartInstance.destroy();
+    }
+
+    chartInstance = new Chart(canvas, {
+        type: 'bar',
+        data: {
+            labels,
+            datasets: [
+                {
+                    label: 'Debit total (£)',
+                    data,
+                    backgroundColor: 'rgba(96, 165, 250, 0.6)',
+                    borderColor: 'rgba(96, 165, 250, 1)',
+                    borderWidth: 1,
+                    borderRadius: 12
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: value => `£${value}`
+                    }
+                }
+            },
+            plugins: {
+                legend: {
+                    display: false
+                },
+                tooltip: {
+                    callbacks: {
+                        label: context => `£${context.parsed.y.toFixed(2)}`
+                    }
+                }
+            }
+        }
+    });
+}
+
+function toggleSelection(id) {
+    if (state.selection.has(id)) {
+        state.selection.delete(id);
+    } else {
+        state.selection.add(id);
+    }
+    render();
+}
+
+function handleSelectAll(event) {
+    const checked = event.target.checked;
+    const filteredTransactions = applyFilters(state.transactions);
+    if (checked) {
+        filteredTransactions.forEach(tx => state.selection.add(tx.id));
+    } else {
+        filteredTransactions.forEach(tx => state.selection.delete(tx.id));
+    }
+    render();
+}
+
+function updateSelectionState(filteredTransactions) {
+    const validIds = new Set(state.transactions.map(tx => tx.id));
+    state.selection.forEach(id => {
+        if (!validIds.has(id)) {
+            state.selection.delete(id);
+        }
+    });
+    const allSelected = filteredTransactions.length > 0 && filteredTransactions.every(tx => state.selection.has(tx.id));
+    const anySelected = filteredTransactions.some(tx => state.selection.has(tx.id));
+    selectAllCheckbox.checked = allSelected;
+    selectAllCheckbox.indeterminate = !allSelected && anySelected;
+    selectionCount.textContent = `${state.selection.size} selected`;
+}
+
+function applyBulkCategory() {
+    const category = bulkCategorySelect.value;
+    if (!category || state.selection.size === 0) {
+        return;
+    }
+    state.transactions.forEach(tx => {
+        if (state.selection.has(tx.id)) {
+            tx.category = category;
+        }
+    });
+    render();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,378 @@
+:root {
+    color-scheme: light dark;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --bg: #0f172a;
+    --card-bg: #111c34cc;
+    --text: #f8fafc;
+    --muted: #cbd5f5;
+    --primary: #60a5fa;
+    --primary-dark: #2563eb;
+    --border: #1e293b;
+    --positive: #22c55e;
+    --negative: #f97316;
+    background-color: #020617;
+    color: var(--text);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, #172554, #020617);
+    display: flex;
+    flex-direction: column;
+}
+
+.app-header {
+    padding: 2.5rem 1.5rem 1rem;
+    text-align: center;
+}
+
+.app-header h1 {
+    font-size: clamp(2rem, 5vw, 3rem);
+    margin: 0;
+    letter-spacing: -0.02em;
+}
+
+.app-header p {
+    margin: 0.75rem auto 0;
+    max-width: 48rem;
+    color: var(--muted);
+}
+
+.layout {
+    width: min(1200px, 92vw);
+    margin: 0 auto;
+    padding-bottom: 4rem;
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 1.5rem;
+    backdrop-filter: blur(18px);
+    box-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.9);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.card-wide {
+    grid-column: 1 / -1;
+}
+
+.card-header h2 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.card-header p {
+    margin: 0.25rem 0 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.upload-area {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.upload-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: rgba(96, 165, 250, 0.15);
+    color: var(--text);
+    padding: 0.75rem 1.5rem;
+    border-radius: 999px;
+    cursor: pointer;
+    border: 1px solid rgba(96, 165, 250, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    width: fit-content;
+}
+
+.upload-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 15px 30px -20px rgba(96, 165, 250, 0.8);
+}
+
+.upload-button input {
+    display: none;
+}
+
+.file-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.file-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    font-size: 0.95rem;
+}
+
+.file-item button {
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    border-radius: 8px;
+    transition: background-color 0.2s ease;
+}
+
+.file-item button:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.category-form {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.category-form input {
+    flex: 1;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="month"],
+input[type="number"],
+select {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 12px;
+    padding: 0.6rem 0.75rem;
+    color: var(--text);
+    font: inherit;
+    width: 100%;
+}
+
+button {
+    border: none;
+    border-radius: 12px;
+    padding: 0.6rem 1.2rem;
+    font: inherit;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button.primary {
+    background: linear-gradient(120deg, var(--primary), var(--primary-dark));
+    color: var(--text);
+}
+
+button.secondary {
+    background: rgba(148, 163, 184, 0.15);
+    color: var(--text);
+}
+
+button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px -15px rgba(15, 23, 42, 0.8);
+}
+
+.category-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.category-pill {
+    background: rgba(96, 165, 250, 0.12);
+    border: 1px solid rgba(96, 165, 250, 0.3);
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+}
+
+.filters,
+.payday-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    min-width: 140px;
+}
+
+.filter-group legend {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.chip-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    padding: 0.3rem 0.65rem;
+    cursor: pointer;
+    user-select: none;
+    font-size: 0.85rem;
+}
+
+.chip input {
+    accent-color: var(--primary);
+}
+
+.payday-note {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.summary-item {
+    background: rgba(15, 23, 42, 0.55);
+    padding: 1rem;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.summary-label {
+    display: block;
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin-bottom: 0.4rem;
+}
+
+.summary-value {
+    font-size: 1.4rem;
+    font-weight: 600;
+}
+
+.summary-value.negative {
+    color: var(--negative);
+}
+
+.summary-value.positive {
+    color: var(--positive);
+}
+
+.bulk-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+}
+
+.bulk-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.selection-count {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.table-container {
+    overflow-x: auto;
+}
+
+.table-container table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+}
+
+thead th {
+    text-align: left;
+    font-weight: 600;
+    padding: 0.75rem 0.5rem;
+    color: var(--muted);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+tbody td {
+    padding: 0.75rem 0.5rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+    vertical-align: middle;
+}
+
+tbody tr:hover {
+    background: rgba(148, 163, 184, 0.08);
+}
+
+tbody tr.selected {
+    background: rgba(96, 165, 250, 0.1);
+}
+
+.empty-state {
+    margin: 0;
+    text-align: center;
+    color: var(--muted);
+}
+
+.chart-wrapper {
+    position: relative;
+    min-height: 320px;
+}
+
+.app-footer {
+    margin-top: auto;
+    text-align: center;
+    padding: 2rem 1rem;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 768px) {
+    .bulk-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .bulk-actions button {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- build a single-page financial tracker that imports multiple CSV statements and manages transaction categorisation
- add filtering by date, transaction type, category, and payday cycles with bulk actions and per-transaction controls
- visualise spending by category and present key totals with a responsive, styled layout

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd386422e4832f81f583d3b1c91635