### PR TITLE
Add transaction search, snapshots, and enhanced category visualisation

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,14 @@
                     <span>Choose CSV files</span>
                 </label>
                 <ul id="file-list" class="file-list" aria-live="polite"></ul>
+                <div class="data-actions">
+                    <button type="button" id="export-data" class="secondary pill">Download snapshot</button>
+                    <label class="ghost-button">
+                        <input type="file" id="restore-input" accept="application/json,.json" />
+                        <span>Restore snapshot</span>
+                    </label>
+                </div>
+                <p class="data-hint">Snapshots let you export your categorised data and load it again later.</p>
             </div>
         </section>
 
@@ -59,6 +67,11 @@
                 <div class="filter-group">
                     <label for="end-date">To</label>
                     <input type="date" id="end-date" />
+                </div>
+                <div class="filter-group filter-search">
+                    <label for="description-search">Search description</label>
+                    <input type="search" id="description-search" placeholder="Type to filter by name" list="description-suggestions" autocomplete="off" />
+                    <datalist id="description-suggestions"></datalist>
                 </div>
                 <fieldset class="filter-group">
                     <legend>Transaction type</legend>
@@ -161,8 +174,13 @@
             <div class="card-header">
                 <h2 id="chart-title">Spending by category</h2>
             </div>
-            <div class="chart-wrapper">
-                <canvas id="category-chart" aria-label="Spending by category"></canvas>
+            <div class="chart-grid">
+                <div class="chart-wrapper">
+                    <canvas id="category-chart" aria-label="Spending by category (bar chart)"></canvas>
+                </div>
+                <div class="chart-wrapper">
+                    <canvas id="category-pie-chart" aria-label="Spending share by category"></canvas>
+                </div>
             </div>
         </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -85,6 +85,42 @@ body {
     gap: 1rem;
 }
 
+.data-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.ghost-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.6);
+    color: var(--text);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ghost-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px -18px rgba(96, 165, 250, 0.7);
+}
+
+.ghost-button input {
+    display: none;
+}
+
+.data-hint {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
 .upload-button {
     display: inline-flex;
     align-items: center;
@@ -153,6 +189,7 @@ body {
 }
 
 input[type="text"],
+input[type="search"],
 input[type="date"],
 input[type="month"],
 input[type="number"],
@@ -183,6 +220,10 @@ button.primary {
 button.secondary {
     background: rgba(148, 163, 184, 0.15);
     color: var(--text);
+}
+
+button.pill {
+    border-radius: 999px;
 }
 
 button:hover {
@@ -216,6 +257,10 @@ button:hover {
     flex-direction: column;
     gap: 0.4rem;
     min-width: 140px;
+}
+
+.filter-search {
+    flex: 1 1 220px;
 }
 
 .filter-group legend {
@@ -341,6 +386,12 @@ tbody tr.selected {
     color: var(--muted);
 }
 
+.chart-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
 .chart-wrapper {
     position: relative;
     min-height: 320px;
@@ -374,5 +425,9 @@ tbody tr.selected {
 
     .bulk-actions button {
         width: 100%;
+    }
+
+    .chart-grid {
+        grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
## Summary
- add description search with autocomplete suggestions and smarter default categorisation heuristics
- support exporting/importing JSON snapshots so categorised data survives refreshes and restores filters
- introduce a spending pie chart and update the UI for the new controls

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dd40c9cebc832fb47bfce85b1a9921