### PR TITLE
Prevent filters form submission from resetting page

### DIFF
--- a/script.js
+++ b/script.js
@@ -130,6 +130,11 @@ if (descriptionSearchInput) {
     descriptionSearchInput.addEventListener('input', handleSearchInput);
     descriptionSearchInput.addEventListener('focus', () => updateSearchSuggestions(state.filters.searchTerm));
 }
+if (filtersForm) {
+    filtersForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+    });
+}
 if (exportButton) {
     exportButton.addEventListener('click', exportDataSnapshot);
 }


### PR DESCRIPTION
## Summary
- prevent the filters form from submitting so pressing Enter in the description search does not reload the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd49519cd8832f8f27e655dd5c52f7