### PR TITLE
Allow spaces in description search

### DIFF
--- a/script.js
+++ b/script.js
@@ -412,8 +412,8 @@ function toggleFilterSet(set, value) {
 }
 
 function handleSearchInput(event) {
-    const value = event.target.value.trim();
-    updateFilter('searchTerm', value);
+    const { value } = event.target;
+    updateFilter('searchTerm', value.trim() ? value : '');
 }
 
 function updateSearchSuggestions(query = '') {


### PR DESCRIPTION
## Summary
- allow the description search filter to keep spaces so multi-word queries work
- treat all-whitespace input as an empty search to avoid accidental filtering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4acadae4832f96427f87c8b3adea