### PR TITLE
Ensure filters clear active transaction selections

### DIFF
--- a/script.js
+++ b/script.js
@@ -1118,5 +1118,18 @@ function clearSelection() {
     if (state.selection.size === 0) {
         return;
     }
+
     state.selection.clear();
+
+    selectAllCheckbox.checked = false;
+    selectAllCheckbox.indeterminate = false;
+    selectionCount.textContent = '0 selected';
+
+    transactionsBody.querySelectorAll('tr.selected').forEach(row => {
+        row.classList.remove('selected');
+    });
+
+    transactionsBody.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+        checkbox.checked = false;
+    });
 }


### PR DESCRIPTION
## Summary
- reset the select-all controls and row checkboxes when clearing the current selection so hidden rows are not modified unexpectedly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9104f6c8832fa47753626935ca07